### PR TITLE
Extend Theme to the login and loading screens.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -155,21 +155,31 @@ function App() {
 
   if (userLoading) {
     return (
-      <div
-        style={{
-          position: 'absolute',
-          left: '50%',
-          top: '50%',
-          transform: 'translate(-50%,-50%)',
-        }}
-      >
-        <CircularProgress />
-      </div>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Container>
+          <div
+            style={{
+              position: 'absolute',
+              left: '50%',
+              top: '50%',
+              transform: 'translate(-50%,-50%)',
+            }}
+          >
+            <CircularProgress />
+          </div>
+        </Container>
+      </ThemeProvider>
     );
   }
 
   if (!user) {
-    return <Login />;
+    return (
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Login />
+      </ThemeProvider>
+    );
   }
   if (window.location.pathname === '/iith-dashboard-pwa') window.location.href = '/';
   return (

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -17,9 +17,6 @@ const login = () => {
     })
     .catch((err) => {
       console.log(err);
-      console.log(process.env.REACT_APP_FIREBASE_AUTH_DOMAIN);
-      console.log(process.env.REACT_APP_FIREBASE_AUTH_DOMAIN);
-      console.log(process.env.REACT_APP_FIREBASE_DATABASE_URL);
     });
 };
 


### PR DESCRIPTION
Fixes #13 .

Screenshot:
Dark theme:
![image](https://user-images.githubusercontent.com/51906583/152974209-e8f02710-a4fd-487b-ac43-c9d5a55cef3b.png)


Currently, only dark theme is possible. This is because we clear the localStorage keys on logout. Hence, the App retrieves no theme pref and defaults to dark.