### PR TITLE
Use Service Worker for caching mess/bus endpoint

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -24,7 +24,8 @@ precacheAndRoute(self.__WB_MANIFEST); //eslint-disable-line
 // Set up App Shell-style routing, so that all navigation requests
 // are fulfilled with your index.html shell. Learn more at
 // https://developers.google.com/web/fundamentals/architecture/app-shell
-const fileExtensionRegexp = new RegExp('/[^/?]+\\.[^/]+$');
+/* eslint-disable-next-line */
+const fileExtensionRegexp = new RegExp("/[^/?]+\\.[^/]+$");
 registerRoute(
   // Return false to exempt requests from being fulfilled by index.html.
   ({ request, url }) => {
@@ -70,3 +71,12 @@ self.addEventListener('message', (event) => {
 });
 
 // Any other custom service worker logic can go here.
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+  // console.log(url);
+  if (url.hostname === 'iith.dev') {
+    event.respondWith(new StaleWhileRevalidate().handle({ event, request }));
+  }
+});

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -50,14 +50,6 @@ export function register(config) {
         registerValidSW(swUrl, config);
       }
     });
-    window.addEventListener("fetch", function (event) {
-      console.log("Request made");
-      event.respondWith(
-        fetch(event.request).catch(function () {
-          return caches.match(event.request);
-        })
-      );
-    });
   }
 }
 


### PR DESCRIPTION
Beginning of service worker implementation

currently, url endpoint is hardcoded to "iith.dev". So this caches only the mess and bus API responses.
current stratergy: Stale-While-Revalidate:

Reference:
https://developer.chrome.com/docs/workbox/modules/workbox-strategies/#stale-while-revalidate

We should discuss on what endpoints to cache, and the strategies. 

